### PR TITLE
Use Site.BaseURL to load CSS and JavaScript files.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,10 +11,10 @@
     <title>{{ .Title }}</title>
 
     <!-- Bootstrap Core CSS -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{{ .Site.BaseURL }}css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom CSS -->
-    <link href="/css/landing-page.css" rel="stylesheet">
+    <link href="{{ .Site.BaseURL }}css/landing-page.css" rel="stylesheet">
 
     <!-- Custom Fonts -->
     <link href="http://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic" rel="stylesheet" type="text/css">

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -1,14 +1,14 @@
 <!-- jQuery Version 1.11.0 -->
-<script src="/js/jquery-1.11.0.js"></script>
+<script src="{{ .Site.BaseURL }}js/jquery-1.11.0.js"></script>
 
 <!-- Plugin JavaScript -->
-<script src="/js/jquery.easing.min.js"></script>
+<script src="{{ .Site.BaseURL }}js/jquery.easing.min.js"></script>
 
 <!-- Bootstrap Core JavaScript -->
-<script src="/js/bootstrap.min.js"></script>
+<script src="{{ .Site.BaseURL }}js/bootstrap.min.js"></script>
 
 <!-- Custom Theme JavaScript -->
-<script src="js/landing-page.js"></script>
+<script src="{{ .Site.BaseURL }}js/landing-page.js"></script>
 
 {{ if isset .Site.Params "googleAnalytics" }}
 


### PR DESCRIPTION
In GitHub pages, project sites are not set on root, e.g.`https://<user>.github.io/<project>/`. To load static files from such URLs, Site.BaseURL should be used.
