### PR TITLE
Fixed format of dates in example site

### DIFF
--- a/exampleSite/content/post/first.md
+++ b/exampleSite/content/post/first.md
@@ -1,5 +1,5 @@
 +++
-date = "2015-12-2T14:10:00+03:00"
+date = "2015-12-02T14:10:00+03:00"
 draft = false
 title = "First Post"
 weight = 1

--- a/exampleSite/content/post/second.md
+++ b/exampleSite/content/post/second.md
@@ -1,5 +1,5 @@
 +++
-date = "2015-12-2T14:10:00+03:00"
+date = "2015-12-02T14:10:00+03:00"
 draft = false
 title = "Second Post"
 weight = 2

--- a/exampleSite/content/post/third.md
+++ b/exampleSite/content/post/third.md
@@ -1,5 +1,5 @@
 +++
-date = "2015-12-2T14:10:00+03:00"
+date = "2015-12-02T14:10:00+03:00"
 draft = false
 title = "Third Post"
 weight = 3


### PR DESCRIPTION
Example site was not building in GitLab Pages. This patch fixes that.