### PR TITLE
Set project logo using a specific path

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -9,6 +9,7 @@ title = "Swiftline"
     project_documentation = "http://swiftline.github.io/docs"
     github_project_name = "swiftline"
     github_user_name = "swiftline"
+    logo = "/img/intro-bg.svg"
 
     first_color="#f8f8f8"
     first_border_color="#e7e7e7"

--- a/layouts/partials/template.css
+++ b/layouts/partials/template.css
@@ -34,3 +34,12 @@ body {
 .header-container h4 {
   color: {{ .Site.Params.header_text_color }};
 }
+
+/* landing page logo */
+.intro-image {
+    height: 100%;
+    min-height: 380px;
+    margin-top: 20px;
+    background: url({{ .Site.Params.logo }}) no-repeat center center;
+    background-size: 280px;
+}

--- a/static/css/landing-page.css
+++ b/static/css/landing-page.css
@@ -195,14 +195,6 @@ p.copyright {
     }
 }
 
-.intro-image {
-    height: 100%;
-    min-height: 380px;
-    margin-top: 20px;
-    background: url(../img/intro-bg.svg) no-repeat center center;
-    background-size: 280px;
-}
-
 .github-btn {
     margin-top: 10px;
 }


### PR DESCRIPTION
Currently the project logo is a svg with fixed name and path. This allows
for more flexibility, letting the user set the path, or even url of the
project logo.